### PR TITLE
Possible enhancements

### DIFF
--- a/src/crypto/alpha/alphacert.rs
+++ b/src/crypto/alpha/alphacert.rs
@@ -181,17 +181,21 @@ impl AlphaCert {
         panic!("tofo")
     }
     */
+}
 
-    pub fn into_ident_cert(self) -> IdentCert<Untrusted> {
+impl From<AlphaCert> for IdentCert<Untrusted> {
+    fn from(alphacert: AlphaCert) -> Self {
         IdentCert::<Untrusted> {
-            inner: Box::new(self),
+            inner: Box::new(alphacert),
             phantom: std::marker::PhantomData,
         }
     }
+}
 
-    pub fn into_device_cert(self) -> DeviceCert<Untrusted> {
+impl From<AlphaCert> for DeviceCert<Untrusted> {
+    fn from(alphacert: AlphaCert) -> Self {
         DeviceCert::<Untrusted> {
-            inner: Box::new(self),
+            inner: Box::new(alphacert),
             phantom: std::marker::PhantomData,
         }
     }

--- a/src/crypto/alpha/alphacert.rs
+++ b/src/crypto/alpha/alphacert.rs
@@ -36,12 +36,6 @@ pub struct AlphaCert {
     issuer: Fingerprint,
 }
 
-impl AsRef<[u8]> for AlphaCert {
-    fn as_ref(&self) -> &[u8] {
-        &self.raw
-    }
-}
-
 impl AlphaCert {
     /// Constructs a new AlphaCert from the given secret and issuer_secret.
     /// If the `issuer` is None, this generateds a selfsigned certificate.
@@ -74,7 +68,7 @@ impl AlphaCert {
             writer.write_sequence(|writer| {
                 writer.next().write_i64(1); // Version
                 writer.next().write_der(&cert_subject_der); // cert data, subject sequence
-                writer.next().write_bytes(signature.as_ref()); // signature for cert
+                writer.next().write_bytes(signature.as_bytes()); // signature for cert
             });
         });
 
@@ -91,7 +85,6 @@ impl AlphaCert {
             issuer: fingerprint,
         }
     }
-
 
     /*
     pub fn build_cert_and_sign_dev(
@@ -273,4 +266,9 @@ impl Cert for AlphaCert {
             )
             .is_ok()
     }
+
+    fn as_bytes(&self) -> &[u8] {
+        self.raw.as_slice()
+    }
+
 }

--- a/src/crypto/alpha/alphacert.rs
+++ b/src/crypto/alpha/alphacert.rs
@@ -81,7 +81,7 @@ impl AlphaCert {
         let fingerprint = if let Some(issuer) = issuer {
             issuer.issuer_fingerprint()
         } else {
-            Fingerprint::from(&cert_signed_der)
+            Fingerprint::from(cert_signed_der.as_slice())
         };
 
         Self {

--- a/src/crypto/alpha/alphacert.rs
+++ b/src/crypto/alpha/alphacert.rs
@@ -93,12 +93,6 @@ impl AlphaCert {
     }
 
 
-    pub fn from_stream(stream: &mut dyn Read) -> Self {
-        let mut raw = Vec::new();
-        stream.read_to_end(&mut raw).unwrap();
-        Self::from(raw.as_slice())
-    }
-
     /*
     pub fn build_cert_and_sign_dev(
         secret: &AlphaSecret,
@@ -234,6 +228,14 @@ impl From<&[u8]> for AlphaCert {
             })
         });
         asn.unwrap()
+    }
+}
+
+impl<Stream: Read> From<&mut Stream> for AlphaCert {
+    fn from(stream: &mut Stream) -> Self {
+        let mut raw = Vec::new();
+        stream.read_to_end(&mut raw).unwrap();
+        Self::from(raw.as_slice())
     }
 }
 

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -33,7 +33,7 @@ use crate::crypto::{
     SignatureBytes, Trusted, Untrusted,
 };
 
-/// Public part of a Alpha keyring, constist of:
+/// Public part of a Alpha keyring, consists of:
 ///  * ED25519 key for signing
 ///  * X25519 key for agreement and crypto
 pub struct AlphaPublic {
@@ -41,7 +41,7 @@ pub struct AlphaPublic {
     x25519_pubkey: x25519::PublicKey,
 }
 
-/// Secret part of a Alpha keyring, constist of:
+/// Secret part of a Alpha keyring, consists of:
 ///  * ED25519 key for signing
 ///  * X25519 key for agreement and crypto
 pub struct AlphaSecret {

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -206,7 +206,7 @@ impl Public for AlphaPublic {
     fn verify(&self, bytes: &[u8], signature: &SignatureBytes) -> bool {
         let public_key = UnparsedPublicKey::new(&signature::ED25519, self.signing_public_key());
         public_key
-            .verify(bytes, signature.as_ref())
+            .verify(bytes, signature.as_bytes())
             .is_ok()
     }
 }

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -24,8 +24,6 @@ use x25519_dalek as x25519;
 use rand::Rng;
 use rand::rngs::OsRng;
 
-use crate::crypto::{CertVariant, PublicVariant, SecretVariant};
-
 type Seed = [u8; SEED_LEN];
 const SEED_LEN: usize = 32;
 

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -13,7 +13,7 @@ use std::io::Write;
 use chrono::Utc;
 use ring::{self, signature::UnparsedPublicKey};
 use ring::{
-    aead, digest, pbkdf2, rand, signature,
+    aead, digest, pbkdf2, signature,
     signature::{Ed25519KeyPair, KeyPair, Signature},
 };
 use snow;
@@ -21,7 +21,8 @@ use yasna::{self, models::GeneralizedTime, models::ObjectIdentifier, Tag};
 
 use x25519_dalek as x25519;
 
-use rand_core::OsRng;
+use rand::Rng;
+use rand::rngs::OsRng;
 
 use crate::crypto::{CertVariant, PublicVariant, SecretVariant};
 
@@ -61,11 +62,9 @@ pub struct AlphaSecret {
 impl AlphaSecret {
     /// Construct a ne AlphaSecret with an ED25519 and X25519 keypair
     pub fn new() -> Self {
-        // TODO reduce to a single random source
-        let rng = rand::SystemRandom::new();
-        let ed25519_seed: [u8; SEED_LEN] = rand::generate(&rng).unwrap().expose();
-        let ed25519_keypair = Ed25519KeyPair::from_seed_unchecked(&ed25519_seed).unwrap();
         let mut rng = OsRng::default();
+        let ed25519_seed: [u8; SEED_LEN] = rng.gen();
+        let ed25519_keypair = Ed25519KeyPair::from_seed_unchecked(&ed25519_seed).unwrap();
         let x25519_secret = x25519::StaticSecret::new(&mut rng);
         let ed25519_pubkey = Vec::from(ed25519_keypair.public_key().as_ref());
         let x25519_pubkey = x25519::PublicKey::from(&x25519_secret);

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -87,7 +87,7 @@ impl AlphaSecret {
 
 impl Secret for AlphaSecret {
     fn sign(&self, bytes: &[u8]) -> SignatureBytes {
-        SignatureBytes::from(self.ed25519_keypair.sign(bytes).as_ref())
+        self.ed25519_keypair.sign(bytes).as_ref().into()
     }
 
     fn decrypt(&self, enc_bytes: &Encrypted, sender_pubkey: &dyn Public) -> Vec<u8> {

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -86,8 +86,8 @@ impl AlphaSecret {
 }
 
 impl Secret for AlphaSecret {
-    fn sign(&self, bytes: &dyn AsRef<[u8]>) -> SignatureBytes {
-        SignatureBytes::from(&self.ed25519_keypair.sign(bytes.as_ref()))
+    fn sign(&self, bytes: &[u8]) -> SignatureBytes {
+        SignatureBytes::from(self.ed25519_keypair.sign(bytes).as_ref())
     }
 
     fn decrypt(&self, enc_bytes: &Encrypted, sender_pubkey: &dyn Public) -> Vec<u8> {
@@ -130,7 +130,7 @@ impl Secret for AlphaSecret {
         }
     }
 
-    fn encrypt(&self, plain_bytes: &dyn AsRef<[u8]>, peer_public: &dyn Public) -> Encrypted {
+    fn encrypt(&self, plain_bytes: &[u8], peer_public: &dyn Public) -> Encrypted {
         match peer_public.as_variant_ref() {
             PublicVariant::Alpha(p) => {
                 // Generate an ephemeral x25519 key
@@ -159,7 +159,7 @@ impl Secret for AlphaSecret {
                     &mut key,
                 );
                 // Encrypt data
-                let mut in_out = Vec::from(plain_bytes.as_ref());
+                let mut in_out = Vec::from(plain_bytes);
                 let mut sealing_key = aead::LessSafeKey::new(
                     aead::UnboundKey::new(&aead::CHACHA20_POLY1305, &key).expect("sealing key"),
                 );
@@ -209,10 +209,10 @@ impl Public for AlphaPublic {
         self.x25519_pubkey.as_bytes()
     }
 
-    fn verify(&self, bytes: &dyn AsRef<[u8]>, signature: &SignatureBytes) -> bool {
+    fn verify(&self, bytes: &[u8], signature: &SignatureBytes) -> bool {
         let public_key = UnparsedPublicKey::new(&signature::ED25519, self.signing_public_key());
         public_key
-            .verify(bytes.as_ref(), signature.as_ref())
+            .verify(bytes, signature.as_ref())
             .is_ok()
     }
     fn as_variant_ref(&self) -> PublicVariant<'_> {

--- a/src/crypto/alpha/alphasecret.rs
+++ b/src/crypto/alpha/alphasecret.rs
@@ -78,11 +78,6 @@ impl AlphaSecret {
             },
         }
     }
-
-    /// Returns the public key parts for this secret
-    pub fn public_key(&self) -> &AlphaPublic {
-        &self.pubkey
-    }
 }
 
 impl Secret for AlphaSecret {
@@ -191,6 +186,10 @@ impl Secret for AlphaSecret {
             });
         });
         stream.write_all(&raw_bytes).unwrap();
+    }
+
+    fn public_key(&self) -> &AlphaPublic {
+        &self.pubkey
     }
 }
 

--- a/src/crypto/alpha/mod.rs
+++ b/src/crypto/alpha/mod.rs
@@ -58,13 +58,13 @@ mod tests {
         let isec = AlphaSecret::new();
         let icert = AlphaCert::new(&isec, &isec, None);
 
-        let untrusted = icert.clone().into_ident_cert();
+        let untrusted = IdentCert::from(icert.clone());
         let trusted = untrusted.into_trusted();
 
         let dsec = AlphaSecret::new();
         let dcert = AlphaCert::new(&dsec, &isec, Some(&icert));
 
-        let dcert = dcert.into_device_cert();
+        let dcert = DeviceCert::from(dcert);
         let dcert_trusted = dcert.into_trusted(trusted.deref());
     }
 }

--- a/src/crypto/cert.rs
+++ b/src/crypto/cert.rs
@@ -26,7 +26,7 @@ use crate::crypto::{
 
 
 /// Cert trait which all Certificate variants must implement.
-pub trait Cert: AsRef<[u8]> {
+pub trait Cert {
     /// Serialize the certificate into ASN.1. The concrete format
     /// is up to the variant implementation. Each implementation must provide
     /// to re-read the serialized data back.
@@ -49,10 +49,11 @@ pub trait Cert: AsRef<[u8]> {
     /// The fingerprint is determined by using a SHA256 digest over
     /// the raw certificate bytes.
     fn fingerprint(&self) -> Fingerprint {
-        let raw = self.as_ref();
-        let d = digest::digest(&digest::SHA256, raw);
+        let d = digest::digest(&digest::SHA256, self.as_bytes());
         let mut inner: [u8; 32] = [0; 32];
         inner.copy_from_slice(&d.as_ref()[0..32]);
         Fingerprint { inner }
     }
+
+    fn as_bytes(&self) -> &[u8];
 }

--- a/src/crypto/fingerprint.rs
+++ b/src/crypto/fingerprint.rs
@@ -26,9 +26,9 @@ pub struct Fingerprint {
     pub inner: [u8; 32],
 }
 
-impl<T: AsRef<[u8]>> From<&T> for Fingerprint {
-    fn from(bytes: &T) -> Self {
-        let d = digest::digest(&digest::SHA256, bytes.as_ref());
+impl From<&[u8]> for Fingerprint {
+    fn from(bytes: &[u8]) -> Self {
+        let d = digest::digest(&digest::SHA256, bytes);
         let mut inner: [u8; 32] = [0; 32];
         inner.copy_from_slice(&d.as_ref()[0..32]);
         Fingerprint { inner }

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -34,7 +34,7 @@ pub trait Public {
     fn encryption_public_key(&self) -> &[u8];
 
     /// Verify raw bytes data and a signature against this public key
-    fn verify(&self, bytes: &dyn AsRef<[u8]>, signature: &SignatureBytes) -> bool;
+    fn verify(&self, bytes: &[u8], signature: &SignatureBytes) -> bool;
 
     /// Returns the concrete variant reference
     fn as_variant_ref(&self) -> PublicVariant;
@@ -43,7 +43,7 @@ pub trait Public {
 /// Trait for secret key information
 pub trait Secret {
     /// Sign raw bytes and return the signature
-    fn sign(&self, bytes: &dyn AsRef<[u8]>) -> SignatureBytes;
+    fn sign(&self, bytes: &[u8]) -> SignatureBytes;
 
     /// Decrypt raw bytes with this key and verify authenticity with `sender_pubkey`.
     fn decrypt(&self, enc_bytes: &Encrypted, sender_pubkey: &dyn Public) -> Vec<u8>;
@@ -55,7 +55,7 @@ pub trait Secret {
     /// Encrypt and sign plaintext bytes
     /// Signing requires the secret key, so this is why encrypt() is not provided
     /// by the Public trait but by the Secret trait.
-    fn encrypt(&self, plain_bytes: &dyn AsRef<[u8]>, peer_public: &dyn Public) -> Encrypted;
+    fn encrypt(&self, plain_bytes: &[u8], peer_public: &dyn Public) -> Encrypted;
 }
 
 

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -55,6 +55,9 @@ pub trait Secret {
     /// Signing requires the secret key, so this is why encrypt() is not provided
     /// by the Public trait but by the Secret trait.
     fn encrypt(&self, plain_bytes: &[u8], peer_public: &Self::PublicKey) -> Encrypted;
+
+    /// Returns the public key part for this secret.
+    fn public_key(&self) -> &Self::PublicKey;
 }
 
 

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -19,9 +19,6 @@ use ring::{
 use snow;
 use yasna::{self, models::GeneralizedTime, models::ObjectIdentifier, Tag};
 
-use crate::crypto::{SecretVariant, PublicVariant, CertVariant};
-
-
 use crate::crypto::SignatureBytes;
 
 

--- a/src/crypto/key.rs
+++ b/src/crypto/key.rs
@@ -35,18 +35,17 @@ pub trait Public {
 
     /// Verify raw bytes data and a signature against this public key
     fn verify(&self, bytes: &[u8], signature: &SignatureBytes) -> bool;
-
-    /// Returns the concrete variant reference
-    fn as_variant_ref(&self) -> PublicVariant;
 }
 
 /// Trait for secret key information
 pub trait Secret {
+    type PublicKey: Public;
+
     /// Sign raw bytes and return the signature
     fn sign(&self, bytes: &[u8]) -> SignatureBytes;
 
     /// Decrypt raw bytes with this key and verify authenticity with `sender_pubkey`.
-    fn decrypt(&self, enc_bytes: &Encrypted, sender_pubkey: &dyn Public) -> Vec<u8>;
+    fn decrypt(&self, enc_bytes: &Encrypted, sender_pubkey: &Self::PublicKey) -> Vec<u8>;
 
     /// Serialize the secret key into ASN.1
     /// The concrete format is up to the implementor.
@@ -55,7 +54,7 @@ pub trait Secret {
     /// Encrypt and sign plaintext bytes
     /// Signing requires the secret key, so this is why encrypt() is not provided
     /// by the Public trait but by the Secret trait.
-    fn encrypt(&self, plain_bytes: &[u8], peer_public: &dyn Public) -> Encrypted;
+    fn encrypt(&self, plain_bytes: &[u8], peer_public: &Self::PublicKey) -> Encrypted;
 }
 
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -49,18 +49,6 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-pub enum CertVariant<'a> {
-    Alpha(&'a self::alpha::AlphaCert),
-}
-
-pub enum SecretVariant<'a> {
-    Alpha(&'a self::alpha::AlphaSecret),
-}
-
-pub enum PublicVariant<'a> {
-    Alpha(&'a self::alpha::AlphaPublic),
-}
-
 pub struct Trusted;
 pub struct Untrusted;
 

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -32,11 +32,9 @@ impl From<&[u8]> for SignatureBytes {
     }
 }
 
-impl SignatureBytes {}
-
-impl AsRef<[u8]> for SignatureBytes {
-    fn as_ref(&self) -> &[u8] {
-        self.inner.as_ref()
+impl SignatureBytes {
+    pub fn as_bytes(&self) -> &[u8] {
+        self.inner.as_slice()
     }
 }
 

--- a/src/crypto/sign.rs
+++ b/src/crypto/sign.rs
@@ -24,10 +24,10 @@ pub struct SignatureBytes {
     inner: Vec<u8>,
 }
 
-impl<T: AsRef<[u8]>> From<&T> for SignatureBytes {
-    fn from(bytes: &T) -> Self {
+impl From<&[u8]> for SignatureBytes {
+    fn from(bytes: &[u8]) -> Self {
         SignatureBytes {
-            inner: Vec::from(bytes.as_ref()),
+            inner: bytes.to_owned(),
         }
     }
 }
@@ -41,14 +41,12 @@ impl AsRef<[u8]> for SignatureBytes {
 }
 
 /// Validate a sigature against a given public key and message.
-pub fn validate_signature<T>(
-    public_key: &T,
-    message: &T,
-    signature: &T,
+pub fn validate_signature(
+    public_key: &[u8],
+    message: &[u8],
+    signature: &[u8],
 ) -> Result<(), ring::error::Unspecified>
-where
-    T: AsRef<[u8]> + ?Sized,
 {
     let public_key = UnparsedPublicKey::new(&signature::ED25519, &public_key);
-    public_key.verify(message.as_ref(), signature.as_ref())
+    public_key.verify(message, signature)
 }


### PR DESCRIPTION
List of possible enhancements (some of them opinionated).

Feel free to pick and choose (or throw all of them away).

Possible future enhancements:
* passing errors on instead of using `unwrap` or `expect` (The `?` operator and the `TryFrom` trait are quite useful for that, also implementing `From<ForeignErrorType> for OwnErrorType` makes `?` convert the errors out of the box)
* Maybe most of the `Box<dyn>` can be replaced with associated types (something like a `Cipher` that consists of a set of several subtypes).
* I'm not sure on the intended use case, but are there plans to have `Vec`s with multiple different types of certificates in them at the same time? If so then this still requires to be object safe, otherwise more stuff can be done.